### PR TITLE
Support video playback rate

### DIFF
--- a/src/PlayerControls.js
+++ b/src/PlayerControls.js
@@ -614,6 +614,14 @@ class PlayerControls {
     this.settingsMenuContent = "settings";
     this.settingsMenu.classList.remove("eluvio-player__controls__settings-menu-hidden");
 
+    const FocusOnFirstMenuItem = () => {
+      // Focus on first element in list when menu opened
+      const firstItem = this.settingsMenu.querySelector("button");
+      if(firstItem) {
+        firstItem.focus();
+      }
+    };
+
     // Resolution settings
     if(this.GetLevels) {
       const levels = this.GetLevels();
@@ -662,15 +670,49 @@ class PlayerControls {
                 });
               });
 
-            // Focus on first element in list when menu opened
-            const firstItem = this.settingsMenu.querySelector("button");
-            if(firstItem) {
-              firstItem.focus();
-            }
+            FocusOnFirstMenuItem();
           });
         }
       }
     }
+
+    // Playback speed
+    if(this.GetPlaybackRate) {
+      const currentPlaybackRate = this.GetPlaybackRate();
+
+      if(this.SetPlaybackRate) {
+        const playbackSpeedButton = CreateElement({
+          parent: this.settingsMenu,
+          type: this.SetPlaybackRate ? "button" : "div",
+          classes: ["eluvio-player__controls__settings-menu__option"]
+        });
+
+        playbackSpeedButton.innerHTML = `Playback speed: ${currentPlaybackRate === 1 ? "Normal" : currentPlaybackRate}`;
+
+        playbackSpeedButton.addEventListener("click", () => {
+          this.settingsMenu.innerHTML = "";
+
+          Array.from({length: 8}, (_, i) => ((i / 4) + 0.25)).forEach(rate => {
+            const rateOption = CreateElement({
+              parent: this.settingsMenu,
+              type: "button",
+              classes: ["eluvio-player__controls__settings-menu__option", rate === currentPlaybackRate ? "eluvio-player__controls__settings-menu__option-selected" : ""]
+            });
+
+            rateOption.innerHTML = rate === 1 ? "Normal" : `${rate}`;
+
+            rateOption.addEventListener("click", () => {
+              this.SetPlaybackRate(rate);
+              this.HideSettingsMenu();
+            });
+
+            FocusOnFirstMenuItem();
+          });
+        });
+      }
+
+    }
+
 
     // Focus on first element in list when menu opened
     const firstItem = this.settingsMenu.querySelector("button");
@@ -693,7 +735,7 @@ class PlayerControls {
     this.settingsButton.addEventListener("click", () => this.ToggleSettings());
   }
 
-  SetQualityControls({GetLevels, SetLevel}) {
+  SetQualityControls({GetLevels, SetLevel, GetPlaybackRate, SetPlaybackRate}) {
     if(
       this.playerOptions.controls === EluvioPlayerParameters.controls.DEFAULT ||
       this.playerOptions.controls === EluvioPlayerParameters.controls.OFF
@@ -706,6 +748,8 @@ class PlayerControls {
 
     this.GetLevels = GetLevels;
     this.SetLevel = SetLevel;
+    this.GetPlaybackRate = GetPlaybackRate;
+    this.SetPlaybackRate = SetPlaybackRate;
   }
 
   InitializeMultiViewControls({AvailableViews, SwitchView}) {

--- a/src/index.js
+++ b/src/index.js
@@ -612,7 +612,11 @@ export class EluvioPlayer {
 
         this.controls.SetQualityControls({
           GetLevels: () => hlsPlayer.levels.map((level, index) => ({index, active: index === hlsPlayer.currentLevel, resolution: level.attrs.RESOLUTION, bitrate: level.bitrate})),
-          SetLevel: levelIndex => hlsPlayer.nextLevel = levelIndex
+          SetLevel: levelIndex => hlsPlayer.nextLevel = levelIndex,
+          GetPlaybackRate: () => this.video.playbackRate,
+          SetPlaybackRate: rate => {
+            this.video.playbackRate = rate;
+          }
         });
 
         hlsPlayer.on(HLSPlayer.Events.FRAG_LOADED, () => {


### PR DESCRIPTION
Add support for playback rate, similar use as changing resolution in the settings menu.

- Hitting <enter> after menu opens selects the first item 
- Rate options are from 0.25 to 2 with an increment of 0.25
- Playback rate menu option is only a button when a callback is provided
- "selected" class is set to current playback rate
- Video slows down and speeds up as expected


<img width="1179" alt="Screen Shot 2022-02-01 at 10 29 28 AM" src="https://user-images.githubusercontent.com/91760982/152028783-5134bc3c-a5ff-4d47-8348-173c025ce742.png">


<img width="1230" alt="Screen Shot 2022-02-01 at 10 12 43 AM" src="https://user-images.githubusercontent.com/91760982/152028135-4a327933-b49c-4272-88a2-e4de68e83f57.png">


