### PR TITLE
Use forked dash.js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@eluvio/elv-client-js": "^4.0.123",
-        "dashjs": "~4.7.0",
+        "dashjs": "git+https://github.com/elv-zenia/dash.js.git#text-track-fix",
         "focus-visible": "^5.2.0",
         "hls.js": "~1.5.12",
         "mux-embed": "^4.30.0",
@@ -3826,8 +3826,7 @@
     },
     "node_modules/dashjs": {
       "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/dashjs/-/dashjs-4.7.4.tgz",
-      "integrity": "sha512-+hldo25QPP3H/NOwqUrvt4uKdMse60/Gsz9AUAnoYfhga8qHWq4nWiojUosOiigbigkDTCAn9ORcvUaKCvmfCA==",
+      "resolved": "git+ssh://git@github.com/elv-zenia/dash.js.git#1d8e7a5bf7365b2371a0cac82f5b8ba125856418",
       "dependencies": {
         "bcp-47-match": "^1.0.3",
         "bcp-47-normalize": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@eluvio/elv-client-js": "^4.0.123",
-    "dashjs": "~4.7.0",
+    "dashjs": "git+https://github.com/elv-zenia/dash.js.git#text-track-fix",
     "focus-visible": "^5.2.0",
     "hls.js": "~1.5.12",
     "mux-embed": "^4.30.0",


### PR DESCRIPTION
dash.js version 4.5.0 introduced a change that breaks Portuguese subtitles because of the formatting (noticed in a tenant). It added a matcher for the parser that checks lang from the MPD and normalizes them into bcp-47 format, which is not ISO 639.